### PR TITLE
Proxy option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,6 +100,20 @@ Example pillar
                distributions:
                  - nightly/trusty
 
+Proxy environment variables (optional) in cron job for mirroring script
+
+.. code-block:: yaml
+
+  aptly:
+    server:
+      enabled: true
+      ...
+      mirror_update:
+        enabled: true
+        http_proxy: "http://1.2.3.4:8000"
+        https_proxy: "http://1.2.3.4:8000"
+      ...
+
 Read more
 =========
 

--- a/aptly/server/mirrors.sls
+++ b/aptly/server/mirrors.sls
@@ -4,7 +4,7 @@
 
 aptly_mirror_update_cron:
   cron.present:
-  - name: "/usr/local/bin/aptly_mirror_update.sh -s"
+  - name: "{% if server.mirror_update.http_proxy is defined %}export http_proxy={{ server.mirror_update.http_proxy }}; {% endif %}{% if server.mirror_update.https_proxy is defined %}export https_proxy={{ server.mirror_update.https_proxy }}; {% endif %}/usr/local/bin/aptly_mirror_update.sh -s"
   - identifier: aptly_mirror_update
   - hour: "{{ server.mirror_update.hour }}"
   - minute: "{{ server.mirror_update.minute }}"

--- a/tests/pillar/default.sls
+++ b/tests/pillar/default.sls
@@ -16,6 +16,8 @@ aptly:
       enabled: true
       hour: 2
       minute: random
+      http_proxy: "http://1.2.3.4:8000"
+      https_proxy: "https://1.2.3.4:8000"
     gpg_passphrase: passphrase
     gpg_private_key: |
       -----BEGIN PGP PRIVATE KEY BLOCK-----


### PR DESCRIPTION
If aptly is running behind proxy, then env variables for proxy are needed to successfully mirror repositories.

Parameters are optional.

Local kitchen test passed.

Hello @fpytloun @epcim could you please, review this request? Thanks.