### PR TITLE
Add a GPG configuration to avoid generating weak hashes.

### DIFF
--- a/aptly/files/gpg.conf
+++ b/aptly/files/gpg.conf
@@ -1,0 +1,2 @@
+cert-digest-algo SHA256
+digest-algo SHA256

--- a/aptly/server/init.sls
+++ b/aptly/server/init.sls
@@ -1,6 +1,7 @@
 {%- from "aptly/map.jinja" import server with context %}
 {%- if server.enabled %}
 
+{% set gpgconffile = '{}/.gnupg/gpg.conf'.format(server.home_dir) %}
 {% set gpgprivfile = '{}/.gnupg/secret.gpg'.format(server.home_dir) %}
 {% set gpgpubfile = '{}/public/public.gpg'.format(server.root_dir) %}
 
@@ -138,6 +139,16 @@ aptly_gpg_key_dir:
   - require:
     - file: aptly_home_dir
 
+gpg_conf_file:
+  file.managed:
+  - name: {{ gpgconffile }}
+  - source: salt://aptly/files/gpg.conf
+  - user: {{ server.user.name }}
+  - group: {{ server.user.group }}
+  - mode: 644
+  - makedirs: true
+  - require:
+    - file: aptly_gpg_key_dir
 
 gpg_priv_key:
   file.managed:


### PR DESCRIPTION
GPG generates SHA1 hashes by default, which is deprecated in apt. Apt then complains about weak signatures.
This GPG configuration file for aptly user solves that.
More info: https://github.com/ros-infrastructure/buildfarm_deployment/issues/130