### PR TITLE
Proxy support and key download from URL.

### DIFF
--- a/aptly/publisher.sls
+++ b/aptly/publisher.sls
@@ -16,6 +16,9 @@ publisher_python_pip:
 publisher_installed:
   pip.installed:
     - name: python-aptly
+    {%- if publisher.source.get('proxy', None) %}
+    - proxy: {{ publisher.source.get('proxy') }}
+    {%- endif %}
     - require:
       - pkg: publisher_python_pip
 

--- a/aptly/schemas/publisher.yaml
+++ b/aptly/schemas/publisher.yaml
@@ -31,3 +31,6 @@ properties:
       registry:
         description: Docker regirsty host for publisher image. Set if installation from docker is chosen
         type: string
+      proxy:
+        description: Proxy for accessing installation source (probably meaningful only for pip source)
+        type: string

--- a/aptly/schemas/server.yaml
+++ b/aptly/schemas/server.yaml
@@ -101,6 +101,9 @@ properties:
       keyring:
         description: Keyring for GPG
         type: string
+      http_proxy:
+        description: HTTP proxy to use for keys download
+        type: string
   api:
     description: Parameters map for for APTLY API services
     type: object


### PR DESCRIPTION
Enhanced proxy support - allow for aptly installed from pip via proxy
Add support for repo key defined via aptly.server.mirror.<mirror_name>.key_url. So far only keys from gpg keyserver were supported.